### PR TITLE
Add JSON dump endpoint

### DIFF
--- a/src/lib/data.ml
+++ b/src/lib/data.ml
@@ -14,6 +14,7 @@ let raw_version s =
 let pp ppf t = Fmt.pf ppf "%s" (string_of_t t)
 let equal a b = String.equal (string_of_t a) (string_of_t b)
 let of_string v = try Ok (t_of_string v) with Failure s -> Error (`Msg s)
+let to_json_string d = string_of_t d
 let t = Irmin.Type.like ~pp ~equal ~of_string Retirement_data.Types.t
 let v ?(version = Retirement_data.latest_version) details = { version; details }
 let details t = t.details

--- a/src/lib/data.mli
+++ b/src/lib/data.mli
@@ -4,6 +4,9 @@ type t
 val of_string : string -> (t, [ `Msg of string ]) result
 (** Parses raw JSON from string into a retirement data. *)
 
+val to_json_string : t -> string
+(** Serialises the data to a JSON string *)
+
 val pp : t Fmt.t
 (** A pretty printer for retirement data *)
 

--- a/src/lib/store.ml
+++ b/src/lib/store.ml
@@ -42,6 +42,22 @@ module Make (S : Project_store) = struct
 
   let get_project_lwt s path = I.get s path
   let get_project s path = get_project_lwt s path |> await
+
+  let get_all_lwt s path =
+    let open Lwt.Syntax in
+    let* items = I.list s path in
+    let+ items =
+      Lwt_list.map_s
+        (fun (s, t) ->
+          let+ t' = S.Tree.to_concrete t in
+          (s, t'))
+        items
+    in
+    List.fold_left
+      (fun acc -> function _, `Contents (c, _) -> c :: acc | _ -> acc)
+      [] items
+
+  let get_all s path = get_all_lwt s path |> await
   let find_project_lwt s path = I.find s path
   let find_project s path = find_project_lwt s path |> await
 end

--- a/src/lib/store_intf.ml
+++ b/src/lib/store_intf.ml
@@ -35,6 +35,9 @@ module type S = sig
   (** [get_project store path] gets the project at [path] in [store]. This will raise
       [Not_found] if there is no value at [path]. *)
 
+  val get_all : I.t -> I.path -> Data.t list
+  (** [get_all store path] finds all of the stored data items at [path]. *)
+
   val find_project : I.t -> I.path -> Data.t option
   (** Like {! get_project} only will wrap [Not_found] into an option. *)
 end


### PR DESCRIPTION
Part of fixing #6 -- this assumes data is stored in `<year>/<month>/<name>.json` format, you can then go to the server and ask for `/json/<year>/<month>` and get a JSON array of all of the retirements.