### PR TITLE
Add types for on-chain data

### DIFF
--- a/src/atd/retirement_data.atd
+++ b/src/atd/retirement_data.atd
@@ -131,3 +131,13 @@ type t <ocaml attr="deriving irmin,graphql"> = {
     ?cost_centre_details <json name="costCentreDetails">: cost_centre_details option;
     ?grant_details <json name="grantDetails">: grant_details option;
 } <ocaml valid="fun x -> match x.finance_kind with `Grant -> Option.is_some x.grant_details | `CostCentre -> Option.is_some x.cost_centre_details">
+
+(* Data that we store on-chain -- should preserve privacy whilst
+   allowing for some level of public accountability *)
+type on_chain = {
+  version : version; (** Version of the on-chain data. *)
+  total_distance <json name="totalDistance">: float; (** Total distance for all flights in retirement. *)
+  total_co2e <json name="totalCo2e">: float; (** Total co2e of all flights stored in kilograms. *)
+  number_of_flights <json name="numberOfFlights">: int; (** Number of flights in this transaction. *)
+  hash : string; (** The unique hash of the corresponding private data. *)
+}

--- a/src/ts/helpers.ts
+++ b/src/ts/helpers.ts
@@ -1,4 +1,8 @@
-import { TrainClass, JourneyTime, TaxiType, Reason, FlightClass } from "./retirement_data"
+import { TrainClass, JourneyTime, TaxiType, Reason, FlightClass, Version } from "./retirement_data"
+
+// The current version for the on-chain data, this needs bumped
+// accordingly when the ATD definition changes
+export const on_chain_version : Version = { major: 0, minor: 1 }
 
 export const allFlightClasses: FlightClass[] = [
   { kind: 'First' /* JSON: "first" */ },

--- a/src/ts/retirement_data.ts
+++ b/src/ts/retirement_data.ts
@@ -139,6 +139,14 @@ export type T = {
   grant_details?: GrantDetails;
 }
 
+export type OnChain = {
+  version: Version;
+  total_distance: number;
+  total_co2e: number;
+  number_of_flights: Int;
+  hash: string;
+}
+
 export function writeVersion(x: Version, context: any = x): any {
   return {
     'major': _atd_write_required_field('Version', 'major', _atd_write_int, x.major, x),
@@ -580,6 +588,26 @@ export function readT(x: any, context: any = x): T {
     finance_kind: _atd_read_required_field('T', 'financeKind', readFinanceKind, x['financeKind'], x),
     cost_centre_details: _atd_read_optional_field(readCostCentreDetails, x['costCentreDetails'], x),
     grant_details: _atd_read_optional_field(readGrantDetails, x['grantDetails'], x),
+  };
+}
+
+export function writeOnChain(x: OnChain, context: any = x): any {
+  return {
+    'version': _atd_write_required_field('OnChain', 'version', writeVersion, x.version, x),
+    'totalDistance': _atd_write_required_field('OnChain', 'total_distance', _atd_write_float, x.total_distance, x),
+    'totalCo2e': _atd_write_required_field('OnChain', 'total_co2e', _atd_write_float, x.total_co2e, x),
+    'numberOfFlights': _atd_write_required_field('OnChain', 'number_of_flights', _atd_write_int, x.number_of_flights, x),
+    'hash': _atd_write_required_field('OnChain', 'hash', _atd_write_string, x.hash, x),
+  };
+}
+
+export function readOnChain(x: any, context: any = x): OnChain {
+  return {
+    version: _atd_read_required_field('OnChain', 'version', readVersion, x['version'], x),
+    total_distance: _atd_read_required_field('OnChain', 'totalDistance', _atd_read_float, x['totalDistance'], x),
+    total_co2e: _atd_read_required_field('OnChain', 'totalCo2e', _atd_read_float, x['totalCo2e'], x),
+    number_of_flights: _atd_read_required_field('OnChain', 'numberOfFlights', _atd_read_int, x['numberOfFlights'], x),
+    hash: _atd_read_required_field('OnChain', 'hash', _atd_read_string, x['hash'], x),
   };
 }
 


### PR DESCRIPTION
We add types for data that is stored on-chain -- this is publicly accessible data for external accountability, but should be privacy preserving. Talking with @sadiqj we figured in this current version iteration total distance, co2e and number of flights should be privacy preserving enough. In the future we may wish to produce histograms or similar to provide a little more insight into the nature of the travel whilst still preserving the privacy for the form submitter.