### PR TITLE
Add offset information to DB

### DIFF
--- a/src/atd/retirement_data.atd
+++ b/src/atd/retirement_data.atd
@@ -123,11 +123,20 @@ type cambridge_id <ocaml attr="deriving irmin,graphql"> = {
   department: string;
 }
 
+type offset <ocaml attr="deriving irmin,graphql"> = {
+    token_id <json name="tokenId">: int;
+    project_name <json name="projectName">: string;
+    minter : string;
+    kyc : string;
+    amount : int;
+}
+
 type t <ocaml attr="deriving irmin,graphql"> = {
     version : version;
     details : travel_details;
     id : cambridge_id;
     finance_kind <json name="financeKind">: finance_kind;
+    offset : offset;
     ?cost_centre_details <json name="costCentreDetails">: cost_centre_details option;
     ?grant_details <json name="grantDetails">: grant_details option;
 } <ocaml valid="fun x -> match x.finance_kind with `Grant -> Option.is_some x.grant_details | `CostCentre -> Option.is_some x.cost_centre_details">

--- a/src/lib/data.ml
+++ b/src/lib/data.ml
@@ -37,13 +37,14 @@ type finance_details =
   [ `Grant of Retirement_data.Types.grant_details
   | `CostCentre of Retirement_data.Types.cost_centre_details ]
 
-let v ?(version = Retirement_data.latest_version) id finance details =
+let v ?(version = Retirement_data.latest_version) id finance details offset =
   match finance with
   | `Grant d ->
       {
         T.version;
         details;
         id;
+        offset;
         finance_kind = `Grant;
         grant_details = Some d;
         cost_centre_details = None;
@@ -53,6 +54,7 @@ let v ?(version = Retirement_data.latest_version) id finance details =
         T.version;
         details;
         id;
+        offset;
         finance_kind = `CostCentre;
         grant_details = None;
         cost_centre_details = Some d;
@@ -79,10 +81,20 @@ let dummy_grant_details =
       task = "task";
     }
 
+let dummy_offset =
+  Retirement_data.Types.
+    {
+      token_id = 1234;
+      project_name = "Gola";
+      minter = "abcd1234wxyz5678";
+      kyc = "1234abcd5678wxyz";
+      amount = 556789;
+    }
+
 let dummy_details =
   v
     { crsid = "abc123"; department = "CST"; name = "Alice" }
-    (`Grant dummy_grant_details) dummy_travel_details
+    (`Grant dummy_grant_details) dummy_travel_details dummy_offset
 
 let details t = t.T.details
 let merge' ~old:_ t1 _t2 = Lwt.return (Ok t1)

--- a/src/lib/data.mli
+++ b/src/lib/data.mli
@@ -35,6 +35,7 @@ val v :
   Retirement_data.Types.cambridge_id ->
   finance_details ->
   Retirement_data.Types.travel_details ->
+  Retirement_data.Types.offset ->
   t
 (** [v ?version details] constructs a new retirement data. If [version] is omitted, the 
     latest version will be used. *)

--- a/src/ts/retirement_data.ts
+++ b/src/ts/retirement_data.ts
@@ -130,11 +130,20 @@ export type CambridgeId = {
   department: string;
 }
 
+export type Offset = {
+  token_id: Int;
+  project_name: string;
+  minter: string;
+  kyc: string;
+  amount: Int;
+}
+
 export type T = {
   version: Version;
   details: TravelDetails;
   id: CambridgeId;
   finance_kind: FinanceKind;
+  offset: Offset;
   cost_centre_details?: CostCentreDetails;
   grant_details?: GrantDetails;
 }
@@ -571,12 +580,33 @@ export function readCambridgeId(x: any, context: any = x): CambridgeId {
   };
 }
 
+export function writeOffset(x: Offset, context: any = x): any {
+  return {
+    'tokenId': _atd_write_required_field('Offset', 'token_id', _atd_write_int, x.token_id, x),
+    'projectName': _atd_write_required_field('Offset', 'project_name', _atd_write_string, x.project_name, x),
+    'minter': _atd_write_required_field('Offset', 'minter', _atd_write_string, x.minter, x),
+    'kyc': _atd_write_required_field('Offset', 'kyc', _atd_write_string, x.kyc, x),
+    'amount': _atd_write_required_field('Offset', 'amount', _atd_write_int, x.amount, x),
+  };
+}
+
+export function readOffset(x: any, context: any = x): Offset {
+  return {
+    token_id: _atd_read_required_field('Offset', 'tokenId', _atd_read_int, x['tokenId'], x),
+    project_name: _atd_read_required_field('Offset', 'projectName', _atd_read_string, x['projectName'], x),
+    minter: _atd_read_required_field('Offset', 'minter', _atd_read_string, x['minter'], x),
+    kyc: _atd_read_required_field('Offset', 'kyc', _atd_read_string, x['kyc'], x),
+    amount: _atd_read_required_field('Offset', 'amount', _atd_read_int, x['amount'], x),
+  };
+}
+
 export function writeT(x: T, context: any = x): any {
   return {
     'version': _atd_write_required_field('T', 'version', writeVersion, x.version, x),
     'details': _atd_write_required_field('T', 'details', writeTravelDetails, x.details, x),
     'id': _atd_write_required_field('T', 'id', writeCambridgeId, x.id, x),
     'financeKind': _atd_write_required_field('T', 'finance_kind', writeFinanceKind, x.finance_kind, x),
+    'offset': _atd_write_required_field('T', 'offset', writeOffset, x.offset, x),
     'costCentreDetails': _atd_write_optional_field(writeCostCentreDetails, x.cost_centre_details, x),
     'grantDetails': _atd_write_optional_field(writeGrantDetails, x.grant_details, x),
   };
@@ -588,6 +618,7 @@ export function readT(x: any, context: any = x): T {
     details: _atd_read_required_field('T', 'details', readTravelDetails, x['details'], x),
     id: _atd_read_required_field('T', 'id', readCambridgeId, x['id'], x),
     finance_kind: _atd_read_required_field('T', 'financeKind', readFinanceKind, x['financeKind'], x),
+    offset: _atd_read_required_field('T', 'offset', readOffset, x['offset'], x),
     cost_centre_details: _atd_read_optional_field(readCostCentreDetails, x['costCentreDetails'], x),
     grant_details: _atd_read_optional_field(readGrantDetails, x['grantDetails'], x),
   };

--- a/test/dummy.json
+++ b/test/dummy.json
@@ -10,6 +10,13 @@
   },
   "id": { "crsid": "abc123", "name": "Alice", "department": "CST" },
   "financeKind": "Grant",
+  "offset": {
+    "tokenId": 1234,
+    "projectName": "Gola",
+    "minter": "abcd1234wxyz5678",
+    "kyc": "1234abcd5678wxyz",
+    "amount": 556789
+  },
   "grantDetails": {
     "sponsorAndPIConfirmation": true,
     "award": "award",

--- a/test/e2e/test_client.ml
+++ b/test/e2e/test_client.ml
@@ -61,6 +61,13 @@ let set_data ~reason =
         department: "CST",
         name: "Alice"
       }
+      offset: {
+        tokenId: 1234,
+        projectName: "Gola",
+        minter: "abcd1234wxyz5678",
+        kyc: "1234abcd5678wxyz",
+        amount: 556789
+      },
       grantDetails: {
         sponsorAndPiConfirmation: true,
         award: "award",

--- a/test/versions/v0_1.json
+++ b/test/versions/v0_1.json
@@ -10,6 +10,13 @@
   },
   "id": { "crsid": "abc123", "name": "Alice", "department": "CST" },
   "financeKind": "Grant",
+  "offset": {
+    "tokenId": 1234,
+    "projectName": "Gola",
+    "minter": "abcd1234wxyz5678",
+    "kyc": "1234abcd5678wxyz",
+    "amount": 556789
+  },
   "grantDetails": {
     "sponsorAndPIConfirmation": true,
     "award": "award",


### PR DESCRIPTION
For linking between the on-chain data and the transaction we'll need more information about the token stored in the private database.