### PR TITLE
Fix serialisation of sponsors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ duniverse
 db
 irmin
 var
+
+*.js

--- a/src/atd/retirement_data.atd
+++ b/src/atd/retirement_data.atd
@@ -102,7 +102,7 @@ type travel_details <ocaml attr="deriving irmin,graphql"> = {
 }
 
 type grant_details <ocaml attr="deriving irmin,graphql"> = {
-  sponsor_and_pi_confirmation <json name="sponsorAndPIConfirmation">: bool;
+  sponsor_and_pi_confirmation <json name="sponsorAndPiConfirmation">: bool;
   award: string;
   project: string;
   task: string;

--- a/test/dummy.json
+++ b/test/dummy.json
@@ -18,7 +18,7 @@
     "amount": 556789
   },
   "grantDetails": {
-    "sponsorAndPIConfirmation": true,
+    "sponsorAndPiConfirmation": true,
     "award": "award",
     "project": "project",
     "task": "task"

--- a/test/versions/v0_1.json
+++ b/test/versions/v0_1.json
@@ -18,7 +18,7 @@
     "amount": 556789
   },
   "grantDetails": {
-    "sponsorAndPIConfirmation": true,
+    "sponsorAndPiConfirmation": true,
     "award": "award",
     "project": "project",
     "task": "task"


### PR DESCRIPTION
There needs to be a one-to-one correspondence between our JSON serialisation format and our GraphQL names -- the Graphql PPX used `SponsorAndPiConfirmation` and our JSON used `SponsorAndPIConfirmation`... subtle. This PR fixes this add the test now uses the serialisation functions to double-check everything works as expected. 