### PR TITLE
Add /get/content/hash endpoint

### DIFF
--- a/retirement.opam
+++ b/retirement.opam
@@ -13,6 +13,7 @@ build: [
 depends: [
   "dune"               {>= "2.9.0"}
   "retirement-data"    {= version}
+  "mtime"              {< "2.0.0"}
   "irmin"              {= "dev"}
   "irmin-fs"           {= "dev"}
   "eio_main"           {>= "0.5"}

--- a/src/atd/retirement_data.atd
+++ b/src/atd/retirement_data.atd
@@ -158,6 +158,10 @@ type set_request = {
     value : t;
 }
 
+type get_content_hash_request = {
+    value : t;
+}
+
 type get_hash_request = {
     commit : string;
     path : string list;

--- a/src/lib/data.ml
+++ b/src/lib/data.ml
@@ -94,6 +94,11 @@ module Rest = struct
 
     let set_to_json = Retirement_data.Json.string_of_set_request
 
+    type get_content_hash = Retirement_data.Types.get_content_hash_request
+
+    let get_content_hash_to_json =
+      Retirement_data.Json.string_of_get_content_hash_request
+
     type get_hash = Retirement_data.Types.get_hash_request
 
     let get_hash_to_json = Retirement_data.Json.string_of_get_hash_request
@@ -109,6 +114,14 @@ module Rest = struct
 
     let set_to_json = Retirement_data.Json.string_of_string_response
     let set_of_json = Retirement_data.Json.string_response_of_string
+
+    type get_content_hash = Retirement_data.Types.string_response
+
+    let get_content_hash_to_json =
+      Retirement_data.Json.string_of_string_response
+
+    let get_content_hash_of_json =
+      Retirement_data.Json.string_response_of_string
 
     type get_hash = Retirement_data.Types.string_response
 

--- a/src/lib/data.mli
+++ b/src/lib/data.mli
@@ -51,6 +51,10 @@ module Rest : sig
 
     val set_to_json : ?len:int -> set -> string
 
+    type get_content_hash = Retirement_data.Types.get_content_hash_request
+
+    val get_content_hash_to_json : ?len:int -> get_content_hash -> string
+
     type get_hash = Retirement_data.Types.get_hash_request
 
     val get_hash_to_json : ?len:int -> get_hash -> string
@@ -66,6 +70,12 @@ module Rest : sig
 
     val set_to_json : ?len:int -> set -> string
     val set_of_json : string -> set
+
+    type get_content_hash = Retirement_data.Types.string_response
+    (** The result of setting a new value in the store, returns the hash of the value. *)
+
+    val get_content_hash_to_json : ?len:int -> set -> string
+    val get_content_hash_of_json : string -> set
 
     type get_hash = Retirement_data.Types.string_response
 

--- a/src/lib/store.ml
+++ b/src/lib/store.ml
@@ -80,4 +80,5 @@ module Make (S : Project_store) = struct
       [] items
 
   let find_project s path = I.find s path
+  let content_hash t = I.Contents.hash t |> Irmin.Type.to_string I.Hash.t
 end

--- a/src/lib/store_intf.ml
+++ b/src/lib/store_intf.ml
@@ -62,6 +62,9 @@ module type S = sig
 
   val find_project : I.t -> I.path -> Data.t option
   (** Like {! get_project} only will wrap [Not_found] into an option. *)
+
+  val content_hash : Data.t -> string
+  (** Digest the content like it would be in the store. *)
 end
 
 module type Make = functor (Arg : Data_store) -> S

--- a/src/ts/retirement_data.ts
+++ b/src/ts/retirement_data.ts
@@ -162,6 +162,10 @@ export type SetRequest = {
   value: T;
 }
 
+export type GetContentHashRequest = {
+  value: T;
+}
+
 export type GetHashRequest = {
   commit: string;
   path: string[];
@@ -684,6 +688,18 @@ export function readSetRequest(x: any, context: any = x): SetRequest {
   return {
     path: _atd_read_required_field('SetRequest', 'path', _atd_read_array(_atd_read_string), x['path'], x),
     value: _atd_read_required_field('SetRequest', 'value', readT, x['value'], x),
+  };
+}
+
+export function writeGetContentHashRequest(x: GetContentHashRequest, context: any = x): any {
+  return {
+    'value': _atd_write_required_field('GetContentHashRequest', 'value', writeT, x.value, x),
+  };
+}
+
+export function readGetContentHashRequest(x: any, context: any = x): GetContentHashRequest {
+  return {
+    value: _atd_read_required_field('GetContentHashRequest', 'value', readT, x['value'], x),
   };
 }
 

--- a/test/e2e/test_client.ml
+++ b/test/e2e/test_client.ml
@@ -70,6 +70,13 @@ let set_and_get_hash ~net host () =
         amount = 556789;
       }
   in
+  let get_content_hash =
+    Retirement_data.Types.{ value } |> Rest.Request.get_content_hash_to_json
+  in
+  let content_hash =
+    req_to_json ~net Rest.Response.get_content_hash_of_json ~host
+      ~path:"/get/content/hash" get_content_hash
+  in
   let string_value =
     Retirement_data.Types.{ path = [ "hello" ]; value }
     |> Rest.Request.set_to_json
@@ -89,9 +96,10 @@ let set_and_get_hash ~net host () =
   let hash = store_value.data in
   let mh = Store.Contents.hash value in
   Alcotest.(check string)
-    "same hash"
+    "same hash locally"
     (Irmin.Type.to_string Store.Hash.t mh)
     hash;
+  Alcotest.(check string) "same hash remotely" content_hash.data hash;
   let get_content_value =
     Retirement_data.Types.{ hash } |> Rest.Request.get_content_to_json
   in


### PR DESCRIPTION
This allows the client to calculate the hash of the value without having to store it. We have two options:

1. Either we store the value without knowing if the transaction on Tezos has gone through, it could fail and then we have stored an untransacted value in the store and the only way to know if it has gone through or not is to check the events of that contract looking for the content hash of this value.
2. Or we don't store the value until we know the transaction has gone through. This gives us the nice invariant that anything stored in the private store has a transaction. But now the possible failure case is in our private store so we could end up with a transaction on chain but no private data for it.

Currently we are doing (1) -- it's not quite clear to me yet which is worse... With a different kind of store this would be okay :S